### PR TITLE
新增易于使用的装饰器

### DIFF
--- a/nonebot_plugin_apscheduler/__init__.py
+++ b/nonebot_plugin_apscheduler/__init__.py
@@ -1,7 +1,8 @@
 import logging
 
-from nonebot import get_driver, export
+from nonebot import get_driver, get_bots, export
 from nonebot.log import logger, LoguruHandler
+from apscheduler.schedulers.base import undefined
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from .config import Config
@@ -10,7 +11,21 @@ driver = get_driver()
 global_config = driver.config
 plugin_config = Config(**global_config.dict())
 
-scheduler = AsyncIOScheduler()
+class Scheduler(AsyncIOScheduler):
+    def scheduled_nonebot_job(self, trigger, args=None, kwargs=None, id=None, name=None,
+                      misfire_grace_time=undefined, coalesce=undefined, max_instances=undefined,
+                      next_run_time=undefined, jobstore='default', executor='default',
+                      **trigger_args):
+        def inner(func):
+            async def func_():
+                for bot in get_bots().values():
+                    await func(bot)
+            self.add_job(func_, trigger, args, kwargs, id, name, misfire_grace_time, coalesce,
+                         max_instances, next_run_time, jobstore, executor, True, **trigger_args)
+            return func
+        return inner
+
+scheduler = Scheduler()
 export().scheduler = scheduler
 
 


### PR DESCRIPTION
新增易于使用的装饰器 `scheduled_nonebot_job`，支持被装饰的函数中定义 `bot: Bot` 参数。